### PR TITLE
Add sign-up form

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# english-vocab-app
+# English Vocabulary Quiz App
+
+This simple web application helps users practice English vocabulary. Choose a CEFR level and test yourself by pronouncing words.
+
+## New Sign-Up Feature
+
+Users are now prompted to sign up with their phone number and email address. The information is stored in the browser's local storage.

--- a/app.js
+++ b/app.js
@@ -81,6 +81,29 @@ document.getElementById("closeStatsBtn").onclick = function() {
   document.getElementById("statsModal").classList.add("hidden");
 };
 
+// Sign up
+document.getElementById("signupBtn").onclick = function() {
+  const phone = document.getElementById("phoneInput").value.trim();
+  const email = document.getElementById("emailInput").value.trim();
+  if (!phone || !email) {
+    alert("Telefon raqam va e-pochta kiriting.");
+    return;
+  }
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    alert("E-pochta noto'g'ri.");
+    return;
+  }
+  localStorage.setItem("user", JSON.stringify({ phone, email }));
+  document.getElementById("signupModal").classList.add("hidden");
+};
+
+window.addEventListener("load", function() {
+  if (!localStorage.getItem("user")) {
+    document.getElementById("signupModal").classList.remove("hidden");
+  }
+});
+
 // Lug‘at (Dictionary)
 document.getElementById("dictionaryBtn").onclick = function() {
   let html = "<h2>So‘zlar ro‘yxati</h2><ul>";

--- a/index.html
+++ b/index.html
@@ -79,6 +79,15 @@
       <button id="closeStatsBtn" class="restart-btn">Yopish</button>
     </div>
   </div>
+  <!-- Sign up modal -->
+  <div id="signupModal" class="hidden">
+    <div class="modal-inner">
+      <h2>Ro'yxatdan o'tish</h2>
+      <input type="text" id="phoneInput" class="input" placeholder="Telefon raqamingiz">
+      <input type="email" id="emailInput" class="input" placeholder="E-pochta">
+      <button id="signupBtn" class="restart-btn">Ro'yxatdan o'tish</button>
+    </div>
+  </div>
   <div id="favoritesModal" class="hidden">
     <div class="modal-inner">
       <div id="favoritesList"></div>

--- a/style.css
+++ b/style.css
@@ -33,7 +33,11 @@
     .light-mode .word { color: #0af; }
     .light-mode .lang-select { background: #fff; color: #111; }
     .light-mode #dictionaryModal .modal-inner { background: #f6f6f6; color: #111; }
-    .badge { font-size: 2rem; margin-bottom: 12px; }
+.badge { font-size: 2rem; margin-bottom: 12px; }
+/* Sign up */
+#signupModal { position: fixed; left:0; top:0; width:100vw; height:100vh; background: rgba(0,0,0,0.88); z-index:1000; display:flex; align-items:center; justify-content:center; }
+#signupModal .modal-inner { background:#fff; color:#222; padding:2rem; border-radius:2rem; width:90%; max-width:400px; }
+.input { width:100%; padding:8px; font-size:1rem; margin:8px 0; border-radius:6px; border:1px solid #ccc; }
     /* Responsive */
     @media (max-width: 900px) { .side { display: none; } .main{ width:100vw;}}
     @media (max-width: 700px) {


### PR DESCRIPTION
## Summary
- allow users to sign up with phone and email stored in localStorage
- style sign-up modal
- document new feature

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684105e2ab24832681be4c8184d83b97